### PR TITLE
Correct Value mapping for other classes

### DIFF
--- a/collibra-core_2.0.0/collibra_core/models/assigned_characteristic_type.py
+++ b/collibra-core_2.0.0/collibra_core/models/assigned_characteristic_type.py
@@ -48,9 +48,9 @@ class AssignedCharacteristicType(object):
     }
 
     discriminator_value_class_map = {
-            'AttributeType'.lower(): '#/components/schemas/AssignedAttributeType',
-            'ComplexRelationType'.lower(): '#/components/schemas/AssignedComplexRelationType',
-            'RelationType'.lower(): '#/components/schemas/AssignedRelationType',
+        'attributetype': 'AssignedAttributeType',
+        'complexrelationtype': 'AssignedComplexRelationType',
+        'relationtype': 'AssignedRelationType',
     }
 
     def __init__(self, assigned_resource_type=None, minimum_occurrences=None, maximum_occurrences=None, assigned_resource_id=None, read_only=None, system=None, id=None):  # noqa: E501

--- a/collibra-core_2.0.0/collibra_core/models/attribute_type.py
+++ b/collibra-core_2.0.0/collibra_core/models/attribute_type.py
@@ -54,13 +54,13 @@ class AttributeType(object):
     }
 
     discriminator_value_class_map = {
-            'BooleanAttributeType'.lower(): '#/components/schemas/BooleanAttributeType',
-            'DateAttributeType'.lower(): '#/components/schemas/DateAttributeType',
-            'MultiValueListAttributeType'.lower(): '#/components/schemas/MultiValueListAttributeType',
-            'NumericAttributeType'.lower(): '#/components/schemas/NumericAttributeType',
-            'ScriptAttributeType'.lower(): '#/components/schemas/ScriptAttributeType',
-            'SingleValueListAttributeType'.lower(): '#/components/schemas/SingleValueListAttributeType',
-            'StringAttributeType'.lower(): '#/components/schemas/StringAttributeType',
+        'booleanattributetype': 'BooleanAttributeType',
+        'dateattributetype': 'DateAttributeType',
+        'multivaluelistattributetype': 'MultiValueListAttributeType',
+        'numericattributetype': 'NumericAttributeType',
+        'scriptattributetype': 'ScriptAttributeType',
+        'singlevaluelistattributetype': 'SingleValueListAttributeType',
+        'stringattributetype': 'StringAttributeType',
     }
 
     def __init__(self, public_id=None, description=None, name=None, last_modified_on=None, resource_type=None, created_by=None, last_modified_by=None, created_on=None, system=None, id=None):  # noqa: E501


### PR DESCRIPTION
fixed the discriminator_value_class_map where openApi spec schemas was referenced instead of the python class.

### Description of your changes

Update the discriminator_value_class_map with the right values

---

### JIRA reference

None
---

### Impact Analysis

none

---

#### Checklist

- [x] I have performed a self-review of my code
- [ ] My code follows the contribution guidelines of this project
- [x] My changes generate no new warnings
